### PR TITLE
Updating license term to enforce citation if used

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+MIT License with Attribution Requirement
+
+Copyright (c) 2025 Arthur Maffre
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Additional Attribution Requirement:
+
+You are free to use, modify, and distribute the code, provided that you include proper attribution to the original author in any derivative works, publications, or presentations that use or reference this code. Specifically:
+
+Retain the copyright notice and this license in all copies or substantial portions of the software.
+Cite this repository in any academic or technical publications as follows:
+
+@misc{maffre2025gflownetllmbayes,
+  author = {Arthur Maffre},
+  title = {GFlowNet_LLM_Bayes: Enhancing LLMs with Causal Reasoning and Bayesian Coherence using GFlowNets},
+  year = {2025},
+  publisher = {GitHub},
+  journal = {GitHub Repository},
+  howpublished = {\url{https://github.com/arthurmaffre/GFlowNet_LLM_Bayes}},
+}
+
+Failure to provide attribution may violate the terms of this license.


### PR DESCRIPTION
# Update LICENSE to Enforce Attribution and Citation

## Description

This pull request updates the `LICENSE` file to include an additional attribution requirement on top of the standard MIT License. The goal is to ensure that users of this repository provide proper credit to the original author in derivative works, publications, or presentations.

### Key Changes:
- **Added Attribution Clause**: 
  - Requires retaining the copyright notice and license in all copies.
  - Mandates citing the repository in academic or technical publications using the provided BibTeX entry.
  - Specifies that failure to provide attribution may violate the license terms.
- **Rationale**: This enforces academic and ethical citation practices while keeping the license permissive (based on MIT). Standard OSS licenses like MIT do not legally require citations, so this custom addition makes it a condition of use.